### PR TITLE
Fix plugin activation error

### DIFF
--- a/includes/admin-menu.php
+++ b/includes/admin-menu.php
@@ -19,7 +19,3 @@ function book_uploader_register_post_type() {
     book_uploader_post_publication();
 }
 add_action('init', 'book_uploader_register_post_type');
-
-function book_uploader_post_publication() {
-    // Add your code here to handle the posting of publications
-}

--- a/includes/display-functions.php
+++ b/includes/display-functions.php
@@ -21,20 +21,3 @@ function book_uploader_display_download_link($content) {
     return $content;
 }
 add_filter('the_content', 'book_uploader_display_download_link');
-
-// Function to handle the posting of publications
-function book_uploader_post_publication() {
-    // Add your code here to handle the posting of publications
-    $args = array(
-        'post_type' => 'libro',
-        'post_status' => 'publish',
-        'numberposts' => -1
-    );
-
-    $books = get_posts($args);
-
-    foreach ($books as $book) {
-        // Perform any necessary actions for each book post
-        // For example, you can update post meta, send notifications, etc.
-    }
-}


### PR DESCRIPTION
Remove duplicate definitions of `book_uploader_post_publication` function to prevent fatal errors.

* **`includes/admin-menu.php`**
  - Remove the duplicate definition of `book_uploader_post_publication`.

* **`includes/display-functions.php`**
  - Remove the duplicate definition of `book_uploader_post_publication`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/someone1a/wordpress-book-plugin?shareId=d77c6fa7-981f-4ff6-8270-67a48088459c).